### PR TITLE
Tweak project settings and fix missing OUI information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,7 @@ xcuserdata
 profile
 *.moved-aside
 
+# OS X
+.DS_Store
+
 Resources/Generic/vendor.db

--- a/KisMac2.xcodeproj/project.pbxproj
+++ b/KisMac2.xcodeproj/project.pbxproj
@@ -376,8 +376,8 @@
 		87CEBA8009AEF03700AEB0B8 /* GrowlController.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = GrowlController.h; sourceTree = "<group>"; };
 		87CEBA8109AEF03700AEB0B8 /* GrowlController.m */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.objc; path = GrowlController.m; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* KisMac2.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KisMac2.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		A505CE401B271A410095C7A0 /* BIGL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = BIGL.framework; path = "/Users/Korich/Library/Developer/Xcode/DerivedData/KisMac2-clnvubjkejewnidwtxzaryobsumq/Build/Products/Debug/BIGL.framework"; sourceTree = "<absolute>"; };
-		A505CE431B271A410095C7A0 /* BIGeneric.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = BIGeneric.framework; path = "/Users/Korich/Library/Developer/Xcode/DerivedData/KisMac2-clnvubjkejewnidwtxzaryobsumq/Build/Products/Debug/BIGeneric.framework"; sourceTree = "<absolute>"; };
+		A505CE401B271A410095C7A0 /* BIGL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BIGL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A505CE431B271A410095C7A0 /* BIGeneric.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BIGeneric.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A529AD761A20A4A100CD8E1E /* en */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A529AD791A20A4B400CD8E1E /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/Crack.xib; sourceTree = "<group>"; };
 		A529AD7B1A20A4B400CD8E1E /* en */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = en; path = en.lproj/GPSDialog.xib; sourceTree = "<group>"; };
@@ -1478,7 +1478,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
 					"$(SRCROOT)/Resources",
-					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/KisMac2-clnvubjkejewnidwtxzaryobsumq/Build/Products/Debug",
+					"$(BUILT_PRODUCTS_DIR)",
 				);
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -1548,7 +1548,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SYSTEM_LIBRARY_DIR)/PrivateFrameworks",
 					"$(SRCROOT)/Resources",
-					"$(USER_LIBRARY_DIR)/Developer/Xcode/DerivedData/KisMac2-clnvubjkejewnidwtxzaryobsumq/Build/Products/Debug",
+					"$(BUILT_PRODUCTS_DIR)",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = KisMAC_Prefix.pch;

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ How Build:
 -------
 * git clone https://github.com/IGRSoft/KisMac2.git ./KissMac2
 * cd KissMac2
-* git submodule update --init
+* git submodule update --init --recursive
 * open KisMac2.xcworkspace
 * Build
 

--- a/Resources/Generic/OUItoVendorDB.pl
+++ b/Resources/Generic/OUItoVendorDB.pl
@@ -9,7 +9,7 @@ use utf8;
 # then generates a vendor.db file usable by KisMAC.
 
 # The latest OUI can be attained by pointing a browser to
-# http://standards.ieee.org/develop/regauth/oui/oui.txt
+# http://standards-oui.ieee.org/oui.txt
 
 
 my $download = "no";
@@ -54,7 +54,7 @@ if($download ne "no"){
 			exit;
 		}
 	} else {
-		$error = system("curl -sf http://standards.ieee.org/develop/regauth/oui/oui.txt -o $ouiFile");
+		$error = system("curl -sf http://standards-oui.ieee.org/oui.txt -o $ouiFile");
 		
 		if($error != 0){
 			print STDERR "There was an error (code $error) during download.\n";


### PR DESCRIPTION
The first commit addresses issues I had when I tried to build. By listing the --recursive option in the build instructions and changing the project to use relative paths to find the BIGeneric and BIGL frameworks, Xcode seems to find everything necessary to build without errors or warnings.

The other fix (the third commit) updates the URL in the script that creates the list of OUIs, which improves on the issue where almost all clients in a scan were listed with the vendor "unknown".