### PR TITLE
Fixes for Issues #60 and #61

### DIFF
--- a/Sources/Driver/USBJack/USBJack.h
+++ b/Sources/Driver/USBJack/USBJack.h
@@ -109,7 +109,7 @@ protected:
     bool                _attachDevice();
     static void         _addDevice(void *refCon, io_iterator_t iterator);
     static void         _handleDeviceRemoval(void *refCon, io_iterator_t iterator);
-    static void         _interruptReceived(void *refCon, IOReturn result, unsigned int len);
+    static void         _interruptReceived(void *refCon, IOReturn result, void *arg0);
 
     int                 initFrameQueue(void);
     int                 destroyFrameQueue(void);

--- a/Sources/Driver/USBJack/rtl8187.mm
+++ b/Sources/Driver/USBJack/rtl8187.mm
@@ -1269,9 +1269,11 @@ IOReturn RTL8187Jack::_init() {
     _priv = (struct rtl8187_priv *)malloc(sizeof(struct rtl8187_priv));
     bzero(_priv, sizeof(struct rtl8187_priv));
 
+    _lockDevice();
     rtl8187_probe();
     NICInitialized = true;
     _deviceInit = true;
+    _unlockDevice();
     DBNSLog(@"_init exit");
     return kIOReturnSuccess;
 }
@@ -1401,8 +1403,10 @@ int  RTL8187Jack::rtl8187_probe(void) {
     return 0;
 }
 bool RTL8187Jack::setChannel(UInt16 channel) {
+    _lockDevice();
     rtl8187_set_channel(_priv, channel);
     _channel = channel;
+    _unlockDevice();
     return YES;
 }
 bool RTL8187Jack::getAllowedChannels(UInt16* channels) {
@@ -1418,7 +1422,9 @@ bool RTL8187Jack::startCapture(UInt16 channel) {
     DBNSLog(@"Start capture");
 	if (NICInitialized) {
         //		DBNSLog(@"Done.\n");
+        _lockDevice();
         rtl8187_start(_priv);
+        _unlockDevice();
         setChannel(channel);
 		return true;
 	}
@@ -1431,7 +1437,9 @@ bool RTL8187Jack::stopCapture() {
     //	DBNSLog(@"Stop capture : ");
 	if (NICInitialized) {
         //		DBNSLog(@"Done.\n");
+        _lockDevice();
         rtl8187_stop(_priv);
+        _unlockDevice();
 		return true;
 	}
 	else {


### PR DESCRIPTION
These are minor changes for review.

My RTL8187 device runs reliably with these changes.

The _lockDevice()/_unlockDevice() pairs are essential.  Many features of the device are programmed by a series of control requests which first set an address, then write data.  If interrupted by another thread that also programs a feature (setting the channel for example), the wrong data can be written to the wrong address.  The device then doesn't work correctly until reset (unplugged/plugged back in).

The fix to _interruptReceived's third parameter probably isn't essential (on a little endian machine at least), but it removes the need to cast its type to IOAsyncCallback1 when passed to ReadPipeAsync().  This is useful in that the compilation will fail if Apple should change IOAsyncCallback1 to something incompatible.