### PR TITLE
Fix for Issue #56

### DIFF
--- a/Sources/3rd Party/FCS.h
+++ b/Sources/3rd Party/FCS.h
@@ -10,9 +10,10 @@
 #ifdef __cplusplus
 extern "C" {
 	#endif
-	
-	unsigned long UPDC32(unsigned long octet, unsigned long crc);
-	
+
+    uint32_t UPDC32(uint32_t octet, uint32_t crc);
+    uint32_t CRC32_block(const uint8_t *p, size_t n, uint32_t crc);
+
 	#ifdef __cplusplus
 	}
 #endif

--- a/Sources/3rd Party/FCS.m
+++ b/Sources/3rd Party/FCS.m
@@ -9,7 +9,7 @@
 
 #include "FCS.h"
 
-typedef unsigned long int UNS_32_BITS;
+typedef uint32_t UNS_32_BITS;
 
 static UNS_32_BITS crc_32_tab[] = { /* CRC polynomial 0xedb88320 */
     0x00000000L, 0x77073096L, 0xee0e612cL, 0x990951baL, 0x076dc419L,
@@ -66,7 +66,19 @@ static UNS_32_BITS crc_32_tab[] = { /* CRC polynomial 0xedb88320 */
     0x2d02ef8dL
 };
 
-unsigned long UPDC32(unsigned long octet, unsigned long crc) 
+uint32_t UPDC32(uint32_t octet, uint32_t crc)
 {
     return (crc_32_tab[((crc) ^ (octet)) & 0xff] ^ ((crc) >> 8));
+}
+
+
+uint32_t CRC32_block(const uint8_t *p, size_t n, uint32_t crc)
+{
+    while ( n-- )
+    {
+        uint32_t octet = *p++;
+        crc = (crc_32_tab[((crc) ^ (octet)) & 0xff] ^ ((crc) >> 8));
+    }
+
+    return crc;
 }

--- a/Sources/Driver/USBJack/IntersilJack.h
+++ b/Sources/Driver/USBJack/IntersilJack.h
@@ -27,7 +27,7 @@ public:
     bool    setChannel(UInt16 channel);
     int     WriteTxDescriptor(WLFrame * theFrame, KMRate kmrate);
     bool    sendKFrame(KFrame *frame);
-    bool    _massagePacket(void *inBuf, void *outBuf, UInt16 len);
+    bool    _massagePacket(void *inBuf, void *outBuf, UInt16 len, UInt16 channel);
     
     IOReturn    _doCommand(enum WLCommandCode cmd, UInt16 param0, UInt16 param1 = 0, UInt16 param2 = 0);
     IOReturn    _doCommandNoWait(enum WLCommandCode cmd, UInt16 param0, UInt16 param1 = 0, UInt16 param2 = 0);

--- a/Sources/Driver/USBJack/IntersilJack.mm
+++ b/Sources/Driver/USBJack/IntersilJack.mm
@@ -269,7 +269,7 @@ bool IntersilJack::sendKFrame(KFrame *frame) {
     return YES;
 }
 
-bool IntersilJack::_massagePacket(void *inBuf, void *outBuf, UInt16 len) {
+bool IntersilJack::_massagePacket(void *inBuf, void *outBuf, UInt16 len, UInt16 /* channel */) {
     unsigned char* pData = (unsigned char *)inBuf;
     WLFrame *head = (WLFrame *)pData;
     KFrame *f = (KFrame *)outBuf;

--- a/Sources/Driver/USBJack/RT73Jack.h
+++ b/Sources/Driver/USBJack/RT73Jack.h
@@ -172,7 +172,7 @@ public:
     bool startCapture(UInt16 channel);
     bool stopCapture();
     
-    bool _massagePacket(void *inBuf, void *outBuf, UInt16 len);
+    bool _massagePacket(void *inBuf, void *outBuf, UInt16 len, UInt16 channel);
 
     int         WriteTxDescriptor(void* theFrame, UInt16 length, UInt8 rate);
     bool        sendKFrame(KFrame *frame);

--- a/Sources/Driver/USBJack/RT73Jack.mm
+++ b/Sources/Driver/USBJack/RT73Jack.mm
@@ -1758,7 +1758,7 @@ bool RT73Jack::stopCapture(){
 }
 
 
-bool RT73Jack::_massagePacket(void *inBuf, void *outBuf, UInt16 len) {
+bool RT73Jack::_massagePacket(void *inBuf, void *outBuf, UInt16 len, UInt16 channel) {
 /*  pr0gg3d: A notice... {len} field that is passed
     is rounded at power of two. Don't use this for
         packet length.
@@ -1787,6 +1787,7 @@ bool RT73Jack::_massagePacket(void *inBuf, void *outBuf, UInt16 len) {
     
     // this is probablty not the most efficient way to do this
     pFrame->ctrl.signal = pRxD->PlcpRssi;    //rssi is the signal level
+    pFrame->ctrl.channel = channel;
     
     // Copy entire packet
     memcpy(pFrame->data, pData + sizeof(RXD_STRUC), pFrame->ctrl.len);

--- a/Sources/Driver/USBJack/RalinkJack.h
+++ b/Sources/Driver/USBJack/RalinkJack.h
@@ -88,7 +88,7 @@ public:
     bool startCapture(UInt16 channel);
     bool stopCapture();
     
-    bool _massagePacket(void *inBuf, void *outBuf, UInt16 len);
+    bool _massagePacket(void *inBuf, void *outBuf, UInt16 len, UInt16 channel);
     int         WriteTxDescriptor(void* theFrame, UInt16 length);
     bool        sendKFrame(KFrame *frame);
     IOReturn    _sendFrame(UInt8* data, IOByteCount size);

--- a/Sources/Driver/USBJack/RalinkJack.mm
+++ b/Sources/Driver/USBJack/RalinkJack.mm
@@ -1145,7 +1145,7 @@ int RalinkJack::WriteTxDescriptor(void* theFrame, UInt16 length) {
     return sizeof(TXD_STRUC);
 }
 
-bool RalinkJack::_massagePacket(void *inBuf, void *outBuf, UInt16 len){
+bool RalinkJack::_massagePacket(void *inBuf, void *outBuf, UInt16 len, UInt16 channel){
     unsigned char* pData = (unsigned char *)inBuf;
     KFrame *pFrame = (KFrame *)outBuf;
     PRXD_STRUC pRxD;
@@ -1186,6 +1186,7 @@ bool RalinkJack::_massagePacket(void *inBuf, void *outBuf, UInt16 len){
         pFrame->ctrl.rate = pRxD->BBR0 / 5;
     }
     pFrame->ctrl.len = pRxD->DataByteCnt - 4;
+    pFrame->ctrl.channel = channel;
     
     memcpy(pFrame->data, pData, pFrame->ctrl.len); 
 

--- a/Sources/Driver/USBJack/USBJack.h
+++ b/Sources/Driver/USBJack/USBJack.h
@@ -117,7 +117,7 @@ protected:
     KFrame *            getFrameFromQueue(UInt16 *len, UInt16 *channel);
     
 	// Method for convert driver native data to KFrame
-    virtual bool        _massagePacket(void *inBuf, void *outBuf, UInt16 len);	
+    virtual bool        _massagePacket(void *inBuf, void *outBuf, UInt16 len, UInt16 channel);	
 
     static void         _runCFRunLoop(USBJack* me);
   

--- a/Sources/Driver/USBJack/USBJack.mm
+++ b/Sources/Driver/USBJack/USBJack.mm
@@ -213,9 +213,8 @@ KFrame *USBJack::receiveFrame()
         receivedFrame = getFrameFromQueue(&len, &channel);
         if (receivedFrame)
         {
-            if(!_massagePacket(receivedFrame, (void *)&_frameBuffer, len))
+            if(!_massagePacket(receivedFrame, (void *)&_frameBuffer, len, channel))
                 continue;
-            ret->ctrl.channel = channel;
             return ret;
         }
         else 
@@ -380,7 +379,7 @@ void USBJack::_interruptReceived(void *refCon, IOReturn result, void *arg0)
     }
         
 }
-bool USBJack::_massagePacket(void *inBuf, void *outBuf, UInt16 len){
+bool USBJack::_massagePacket(void *inBuf, void *outBuf, UInt16 len, UInt16 /* channel */) {
     return true;         //override if needed
 }
 

--- a/Sources/Driver/USBJack/rtl8187.h
+++ b/Sources/Driver/USBJack/rtl8187.h
@@ -128,7 +128,7 @@ public:
     bool setChannel(UInt16 channel);
     bool startCapture(UInt16 channel);    
     bool getAllowedChannels(UInt16* channels);
-    bool _massagePacket(void *inBuf, void *outBuf, UInt16 len);
+    bool _massagePacket(void *inBuf, void *outBuf, UInt16 len, UInt16 channel);
     bool stopCapture();
     
     int         WriteTxDescriptor(void* theFrame, UInt16 length, UInt8 rate);

--- a/Sources/Driver/USBJack/rtl8187.mm
+++ b/Sources/Driver/USBJack/rtl8187.mm
@@ -1448,7 +1448,7 @@ bool RTL8187Jack::stopCapture() {
 	}
 }
 
-bool RTL8187Jack::_massagePacket(void *inBuf, void *outBuf, UInt16 len) {
+bool RTL8187Jack::_massagePacket(void *inBuf, void *outBuf, UInt16 len, UInt16 channel) {
     
     unsigned char* pData = (unsigned char *)inBuf;    
     KFrame *pFrame = (KFrame *)outBuf;
@@ -1486,6 +1486,7 @@ bool RTL8187Jack::_massagePacket(void *inBuf, void *outBuf, UInt16 len) {
 	}
     pFrame->ctrl.signal = (UInt8)((100.0 / 65.0) * signal);
     pFrame->ctrl.silence = 0;
+    pFrame->ctrl.channel = channel;
 
 //    dumpFrame(pData, len);
             


### PR DESCRIPTION
This ignores frames with an invalid FCS for the one case that I can test (DLT_IEEE802_11_RADIO_AVS).

The channel reported by the driver was being overwritten by USBJack after calling _massagePacket.  Pass the channel into _massagePacket so the driver can set it itself.

This request is 'for the record'.