### PR TITLE
Add support for GPS receivers appearing as modems

### DIFF
--- a/Sources/Preferences/PreferencePanes/PrefsGPS.m
+++ b/Sources/Preferences/PreferencePanes/PrefsGPS.m
@@ -112,7 +112,7 @@
 			CFDictionarySetValue (
 								  classesToMatch,
 								  CFSTR (kIOSerialBSDTypeKey),
-								  CFSTR (kIOSerialBSDRS232Type));
+								  CFSTR (kIOSerialBSDAllTypes));
 			kernResult = IOServiceGetMatchingServices (
 													   masterPort, classesToMatch, &serialIterator);
 			if (KERN_SUCCESS == kernResult)


### PR DESCRIPTION
E.g. a u-blox UBX-G7020 based GPS receiver from AliExpress shows
up as /dev/tty.usbmodemFD131.
